### PR TITLE
Don't raise on binary file

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -74,7 +74,7 @@ class Tint < Sinatra::Base
           end
         end
       else
-        raise 'Editing binary files is not supported'
+        'Editing binary files is not supported'
       end
     end
   end


### PR DESCRIPTION
At least return an error to the user.

Closes #46